### PR TITLE
Added support for 'table-layout' property

### DIFF
--- a/lib/lint/strict-property-order.js
+++ b/lib/lint/strict-property-order.js
@@ -150,6 +150,7 @@ var _ = require('underscore')
     , 'box-pack'
     , 'box-shadow'
     , 'box-sizing'
+    , 'table-layout'
     , 'animation'
     , 'animation-delay'
     , 'animation-duration'


### PR DESCRIPTION
Added 'table-layout' to strict-property-order.js to prevent 'Unknown property name: "table-layout"' errors.

https://developer.mozilla.org/en/CSS/table-layout

Unsure of where it should feature in the order with respect to the twitter style guide, but I've added it just after the box-sizing property it seems to make sense to put it there from a semantic point of view. 

Feel free to reject if you feel it's better situated elsewhere in the property order. 

Thanks,
Tom 
