### PR TITLE
Added 'pointer-events' to strict-property-order.js

### DIFF
--- a/lib/lint/strict-property-order.js
+++ b/lib/lint/strict-property-order.js
@@ -95,6 +95,7 @@ var _ = require('underscore')
     , 'list-style-type'
     , 'list-style-position'
     , 'list-style-image'
+    , 'pointer-events'
     , 'cursor'
     , 'background'
     , 'background-attachment'


### PR DESCRIPTION
Added 'pointer-events' just above 'cursor' in strict-property-order.js, as this seemed like the most logical place for it. This fixes the 'Unknown property name' error when using pointer-event.
