### PR TITLE
Add line number as own entity in lint error data-structure.

### DIFF
--- a/lib/lint/inline-images.js
+++ b/lib/lint/inline-images.js
@@ -28,6 +28,7 @@ module.exports = function (def, data) {
   // loop over selectors
   def.rules.forEach(function (rule) {
     var extract
+      , line
 
     // continue to next rule if no url is present
     if ( !(rule.value
@@ -35,8 +36,8 @@ module.exports = function (def, data) {
         && RULE.exp.test(rule.value.toCSS({}))) ) return
 
     // calculate line number for the extract
-    extract = util.getLine(rule.index, data)
-    extract = util.padLine(extract)
+    line = util.getLine(rule.index, data)
+    extract = util.padLine(line)
 
     // highlight invalid 0 units
     extract += rule.toCSS({}).replace(RULE.exp, function ($1) {
@@ -51,6 +52,7 @@ module.exports = function (def, data) {
       type: RULE.type
     , message: RULE.message
     , extract: extract
+    , line: line
     })
 
   })

--- a/lib/lint/no-IDs.js
+++ b/lib/lint/no-IDs.js
@@ -32,13 +32,14 @@ module.exports = function (def, data) {
     selector.elements.forEach(function (element) {
 
       var extract
+        , line
 
       // continue to next element if no js- prefix
       if (!RULE.exp.test(element.value)) return
 
       // calculate line number for the extract
-      extract = util.getLine(element.index - element.value.length, data)
-      extract = util.padLine(extract)
+      line = util.getLine(element.index - element.value.length, data)
+      extract = util.padLine(line)
 
       // highlight invalid styling of ID
       extract += element.value.replace(RULE.exp, '#'.magenta)
@@ -51,6 +52,7 @@ module.exports = function (def, data) {
         type: RULE.type
       , message: RULE.message
       , extract: extract
+      , line: line
       })
 
     })

--- a/lib/lint/no-JS-prefix.js
+++ b/lib/lint/no-JS-prefix.js
@@ -32,13 +32,14 @@ module.exports = function (def, data) {
     selector.elements.forEach(function (element) {
 
       var extract
+        , line
 
       // continue to next element if .js- prefix not styled
       if (!RULE.exp.test(element.value)) return
 
       // calculate line number for the extract
-      extract = util.getLine(element.index - element.value.length, data)
-      extract = util.padLine(extract)
+      line = util.getLine(element.index - element.value.length, data)
+      extract = util.padLine(line)
 
       // highlight invalid styling of .js- prefix
       extract += element.value.replace(RULE.exp, '.js-'.magenta)
@@ -51,6 +52,7 @@ module.exports = function (def, data) {
         type: RULE.type
       , message: RULE.message
       , extract: extract
+      , line: line
       })
 
     })

--- a/lib/lint/no-overqualifying.js
+++ b/lib/lint/no-overqualifying.js
@@ -31,13 +31,14 @@ module.exports = function (def, data) {
     // evaluate selector to string and trim whitespace
     var selectorString = selector.toCSS().trim()
       , extract
+      , line
 
     // if selector isn't overqualified continue
     if (!RULE.exp.test(selectorString)) return
 
     // calculate line number for the extract
-    extract = util.getLine(selector.elements[0].index - selector.elements[0].value.length, data)
-    extract = util.padLine(extract)
+    line = util.getLine(selector.elements[0].index - selector.elements[0].value.length, data)
+    extract = util.padLine(line)
 
     // highlight selector overqualification
     extract += selectorString.replace(RULE.exp, function ($1) { return $1.magenta })
@@ -50,6 +51,7 @@ module.exports = function (def, data) {
       type: RULE.type
     , message: RULE.message
     , extract: extract
+    , line: line
     })
 
   })

--- a/lib/lint/no-underscores.js
+++ b/lib/lint/no-underscores.js
@@ -32,13 +32,14 @@ module.exports = function validate(def, data) {
     selector.elements.forEach(function (element) {
 
       var extract
+        , line
 
       // continue to next element if no underscore
       if (!RULE.exp.test(element.value)) return
 
       // calculate line number for the extract
-      extract = util.getLine(element.index - element.value.length, data)
-      extract = util.padLine(extract)
+      line = util.getLine(element.index - element.value.length, data)
+      extract = util.padLine(line)
 
       // highlight invalid underscores
       extract += element.value.replace(RULE.exp, '_'.magenta)
@@ -51,6 +52,7 @@ module.exports = function validate(def, data) {
         type: RULE.type
       , message: RULE.message
       , extract: extract
+      , line: line
       })
 
     })

--- a/lib/lint/no-universal-selectors.js
+++ b/lib/lint/no-universal-selectors.js
@@ -32,13 +32,14 @@ module.exports = function (def, data) {
     selector.elements.forEach(function (element) {
 
       var extract
+        , line
 
       // continue to next element if no underscore
       if (!RULE.exp.test(element.value)) return
 
       // calculate line number for the extract
-      extract = util.getLine(element.index - element.value.length, data)
-      extract = util.padLine(extract)
+      line = util.getLine(element.index - element.value.length, data)
+      extract = util.padLine(line)
 
       // highlight the invalid use of a universal selector
       extract += selector.toCSS({}).replace(RULE.exp, '*'.magenta)
@@ -51,6 +52,7 @@ module.exports = function (def, data) {
         type: RULE.type
       , message: RULE.message
       , extract: extract
+      , line: line
       })
 
     })

--- a/lib/lint/strict-property-order.js
+++ b/lib/lint/strict-property-order.js
@@ -274,6 +274,7 @@ module.exports = function (def, data) {
   , message: RULE.message + selector + '\n\n  Correct order below:\n'.grey
   , extract: extract
   , sortedRules: sortedRules
+  , line: firstLine
   })
 
   // return valid state

--- a/lib/lint/zero-units.js
+++ b/lib/lint/zero-units.js
@@ -39,6 +39,7 @@ module.exports = function (def, data) {
   // loop over rules
   def.rules.forEach(function (rule) {
     var extract
+      , line
 
     // continue to next rule if no 0 units are present
     if ( !(rule.value
@@ -46,8 +47,8 @@ module.exports = function (def, data) {
         && RULE.exp.test(rule.value.toCSS({}))) ) return
 
     // calculate line number for the extract
-    extract = util.getLine(rule.index, data)
-    extract = util.padLine(extract)
+    line = util.getLine(rule.index, data)
+    extract = util.padLine(line)
 
     // highlight invalid 0 units
     extract += rule.toCSS({}).replace(RULE.exp, function ($1) {
@@ -62,6 +63,7 @@ module.exports = function (def, data) {
       type: RULE.type
     , message: RULE.message
     , extract: extract
+    , line: line
     })
 
   })

--- a/test/types/lint.js
+++ b/test/types/lint.js
@@ -65,6 +65,7 @@ var assert = require('assert')
   assert.ok(Recess.definitions[0].errors)
   assert.equal(Recess.definitions[0].errors.length, 1, 'one error found')
   assert.equal(Recess.definitions[0].errors[0].type, 'strictPropertyOrder', 'strictPropertyOrder exception raised')
+  assert.equal(Recess.definitions[0].errors[0].line, 5, 'Correct line number reported')
   assert.equal(Recess.definitions[0].errors[0].sortedRules.length, Recess.definitions[0].rules.length, 'same rule length in property')
   assert.equal(Recess.definitions[0].errors[0].sortedRules[0].name, 'position', 'Correctly ordered')
   assert.equal(Recess.definitions[0].errors[0].sortedRules[1].name, 'display', 'Correctly ordered')
@@ -84,6 +85,7 @@ var assert = require('assert')
   var path = 'test/fixtures/no-JS.css'
     , Recess = new RECESS.Constructor()
     , validate = RECESS.Constructor.prototype.validate
+    , lines = [7, 8, 16, 16, 21, 21]
 
   RECESS.Constructor.prototype.validate = noop
 
@@ -99,7 +101,9 @@ var assert = require('assert')
 
     assert.equal(def.errors.length, 2, 'one error found')
     assert.equal(def.errors[0].type, 'noJSPrefix')
+    assert.equal(def.errors[0].line, lines.shift(), 'Correct line number reported')
     assert.equal(def.errors[1].type, 'noJSPrefix')
+    assert.equal(def.errors[1].line, lines.shift(), 'Correct line number reported')
 
   })
 
@@ -114,6 +118,7 @@ var assert = require('assert')
   var path = 'test/fixtures/no-IDs.css'
     , Recess = new RECESS.Constructor()
     , validate = RECESS.Constructor.prototype.validate
+    , lines = [1, 7, 13]
 
   RECESS.Constructor.prototype.validate = noop
 
@@ -128,6 +133,7 @@ var assert = require('assert')
     assert.ok(def.errors)
     assert.equal(def.errors.length, 1, 'one error found')
     assert.equal(def.errors[0].type, 'noIDs')
+    assert.equal(def.errors[0].line, lines.shift(), 'Correct line number reported')
 
   })
 
@@ -141,6 +147,7 @@ var assert = require('assert')
   var path = 'test/fixtures/no-underscores.css'
     , Recess = new RECESS.Constructor()
     , validate = RECESS.Constructor.prototype.validate
+    , lines = [1, 6, 6]
 
   RECESS.Constructor.prototype.validate = noop
 
@@ -155,6 +162,7 @@ var assert = require('assert')
     assert.ok(def.errors)
     assert.equal(def.errors.length, 1, 'one error found')
     assert.equal(def.errors[0].type, 'noUnderscores')
+    assert.equal(def.errors[0].line, lines.shift(), 'Correct line number reported')
 
   })
 
@@ -168,7 +176,8 @@ var assert = require('assert')
   var path = 'test/fixtures/universal-selectors.css'
     , Recess = new RECESS.Constructor()
     , validate = RECESS.Constructor.prototype.validate
-    , def
+    , counts = [1, 3, 1]
+    , lines = [1, 5, 6, 7, 11]
 
   RECESS.Constructor.prototype.validate = noop
 
@@ -176,13 +185,17 @@ var assert = require('assert')
 
   Recess.parse()
 
-  def = Recess.definitions[0]
+  Recess.definitions.forEach(function (def) {
 
-  RECESS.Constructor.RULES.noUniversalSelectors(def, Recess.data)
+    RECESS.Constructor.RULES.noUniversalSelectors(def, Recess.data)
 
-  assert.ok(def.errors)
-  assert.equal(def.errors.length, 1, 'one error found')
-  assert.equal(def.errors[0].type, 'noUniversalSelectors')
+    assert.ok(def.errors)
+    assert.equal(def.errors.length, counts.shift(), 'Correct error count found')
+    def.errors.forEach(function (error) {
+      assert.equal(error.type, 'noUniversalSelectors')
+      assert.equal(error.line, lines.shift(), 'Correct line number reported')
+    })
+  })
 
   RECESS.Constructor.prototype.validate = validate
 
@@ -194,7 +207,8 @@ var assert = require('assert')
   var path = 'test/fixtures/no-overqualifying.css'
     , Recess = new RECESS.Constructor()
     , validate = RECESS.Constructor.prototype.validate
-    , def
+    , counts = [1, 2]
+    , lines = [1, 7, 8]
 
   RECESS.Constructor.prototype.validate = noop
 
@@ -202,13 +216,16 @@ var assert = require('assert')
 
   Recess.parse()
 
-  def = Recess.definitions[0]
+  Recess.definitions.forEach(function (def) {
+    RECESS.Constructor.RULES.noOverqualifying(def, Recess.data)
 
-  RECESS.Constructor.RULES.noOverqualifying(def, Recess.data)
-
-  assert.ok(def.errors)
-  assert.equal(def.errors.length, 1, 'one error found')
-  assert.equal(def.errors[0].type, 'noOverqualifying')
+    assert.ok(def.errors)
+    assert.equal(def.errors.length, counts.shift(), 'Correct error count found')
+    def.errors.forEach(function (error) {
+      assert.equal(error.type, 'noOverqualifying')
+      assert.equal(error.line, lines.shift(), 'Correct line number reported')
+    })
+  })
 
   RECESS.Constructor.prototype.validate = validate
 
@@ -220,7 +237,8 @@ var assert = require('assert')
   var path = 'test/fixtures/inline-images.css'
     , Recess = new RECESS.Constructor()
     , validate = RECESS.Constructor.prototype.validate
-    , def
+    , counts = [1, 1, 1, 0]
+    , lines = [2, 5, 8]
 
   RECESS.Constructor.prototype.validate = noop
 
@@ -228,13 +246,20 @@ var assert = require('assert')
 
   Recess.parse()
 
-  def = Recess.definitions[0]
+  Recess.definitions.forEach(function (def) {
+    RECESS.Constructor.RULES.inlineImages(def, Recess.data)
 
-  RECESS.Constructor.RULES.inlineImages(def, Recess.data)
-
-  assert.ok(def.errors)
-  assert.equal(def.errors.length, 1, 'one error found')
-  assert.equal(def.errors[0].type, 'inlineImages')
+    if (counts[0]) {
+      assert.ok(def.errors)
+      assert.equal(def.errors.length, counts.shift(), 'Correct error count found')
+      def.errors.forEach(function (error) {
+        assert.equal(def.errors[0].type, 'inlineImages')
+        assert.equal(error.line, lines.shift(), 'Correct line number reported')
+      })
+    } else {
+      assert.ok(!def.errors)
+    }
+  })
 
   RECESS.Constructor.prototype.validate = validate
 


### PR DESCRIPTION
Patch to add the line numbers of errors to the error data-structure from linters, so that code using Recess as a library doesn't have to parse the "extract" to get at the line numbers.

The way I've added this to the unit tests is least-change but it's a bit fugly, sorry about that. :)
