### PR TITLE
Parser should log LessError's type, not name - Fixes #18

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -86,7 +86,7 @@ RECESS.prototype = {
             that.errors.push(err)
 
             // less gave up trying to parse the data ;_;
-            that.log(err.name.red + ": " + err.message + ' of ' + err.filename.yellow + '\n')
+            that.log(err.type.red + ": " + err.message + ' of ' + err.filename.yellow + '\n')
 
             // if extract - then log it
             err.extract && err.extract.forEach(function (line, index) {


### PR DESCRIPTION
twitter/recess#18

Looking through the less source it seems that [`LessError`](https://github.com/cloudhead/less.js/blob/master/lib/less/parser.js#L219) has no name, yet the core parser attempts to log it.  This is  causing:

```
Parse error: Cannot read property 'red' of undefined on line {lineno}
```

... which is actually a `TypeError` thrown for attemping to call `err.name.red`, when `err.name` is undefined.

The fix is super simple, just logging the error's type instead of the name.
