### PR TITLE
Fix inlineImages when the less/css-file is in the current directory

### DIFF
--- a/lib/compile/inline-images.js
+++ b/lib/compile/inline-images.js
@@ -26,7 +26,7 @@ function compile () {
       , mimetype = 'image/' + ext.replace(/jpg/, 'jpeg')
       , pathParts = path.split(seperator)
       , filePath = pathParts.slice(0, pathParts.length - 1).join(seperator)
-      , imgBuffer = new Buffer(fs.readFileSync(filePath+seperator+fileName)).toString('base64')
+      , imgBuffer = new Buffer(fs.readFileSync((filePath?filePath:'.')+seperator+fileName)).toString('base64')
       , urlData = 'url(data:' + mimetype + ';base64,' + imgBuffer + ')'
 
     return props.replace(/url\([^\)]*\)/, urlData)


### PR DESCRIPTION
Fix inlineImages when the less/css-file is in the current directory (and therefor does not have a diretory-component)

before:

```
recess --compile --inlineImages true test.less
```

transforms all relative urls wrong, since test.less had no directory
f.e.:
img/sprite.png ===> /img/sprite.png

```
recess --compile --inlineImages true ./test.less
```

did work
img/sprite.png ===> ./img/sprite.png

with this patch,

```
recess --compile --inlineImages true test.less
```

works, too

Signed-off-by: Tim Riemenschneider git@tim-riemenschneider.de
