### PR TITLE
Remove silly magic, always return an array, even when single

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -59,7 +59,7 @@ module.exports = function (paths, options, callback) {
     err = err.length ? err[0] : null
 
     //callback
-    callback && callback(err, instances.length > 1 ? instances : instances[0])
+    callback && callback(err, instances)
   }
 
   // start processing paths

--- a/test/types/compile.js
+++ b/test/types/compile.js
@@ -12,7 +12,7 @@ fs.readdirSync('test/fixtures').forEach(function (file, index) {
   RECESS('test/fixtures/' + file, { compile: true, inlineImages: true  }, function (err, fat) {
     file = file.replace(/less$/, 'css')
     assert.ok(err == null)
-    assert.ok(fat.output[0] == fs.readFileSync('test/compiled/' + file, 'utf-8'))
+    assert.ok(fat[0].output[0] == fs.readFileSync('test/compiled/' + file, 'utf-8'))
   })
 
 })


### PR DESCRIPTION
Fixes #44

Currently the recess() method returns a single object if you only call it with one file and an array of objects if you call it with multiple. This is bad practice and in this case it should always return an array, even with only one item.
