### PR TITLE
Added another try/catch for tree.toCSS

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -84,20 +84,9 @@ RECESS.prototype = {
           if (err) {
             // push to errors array
             that.errors.push(err)
-
-            if (err.type == 'Parse') {
-              // parse error
-              that.log("Parser error".red + (err.filename ? ' in ' + err.filename : '') + '\n')
-            } else {
-              // other exception
-              that.log(err.name.red + ": " + err.message + ' of ' + err.filename.yellow + '\n')
-            }
-
-            // if extract - then log it
-            err.extract && err.extract.forEach(function (line, index) {
-              that.log(util.padLine(err.line + index) + line)
-            })
-
+            
+            that.log(less.formatError(err, {color: !that.options.stripColors}))
+            
             // add extra line for readability after error log
             that.log(" ")
 
@@ -109,7 +98,17 @@ RECESS.prototype = {
           if (/less$/.test(that.path) && !that.parsed) {
 
             // if it's a LESS file, we flatten it
-            that.data = tree.toCSS({})
+            try{
+              that.data = tree.toCSS({})
+            }catch(err){
+              // less exploded trying to compile the file (╯°□°）╯︵ ┻━┻
+              
+              // push to errors array
+              that.errors.push(err)
+              
+              // log a message trying to explain why
+              that.log(less.formatError(err, {color: !that.options.stripColors}))
+            }
 
             // set parse to true so as to not infinitely reparse less files
             that.parsed = true
@@ -126,19 +125,12 @@ RECESS.prototype = {
         })
 
     } catch (err) {
-
       // less exploded trying to parse the file (╯°□°）╯︵ ┻━┻
       // push to errors array
       that.errors.push(err)
 
       // log a message trying to explain why
-      that.log(
-          "Parse error".red
-        + ": "
-        + err.message
-        + " on line "
-        + util.getLine(err.index, this.data)
-      )
+      that.log(less.formatError(err, {color: !that.options.stripColors}))
 
       // exit with callback if present
       this.callback && this.callback()

--- a/test/compiled/zero-units.css
+++ b/test/compiled/zero-units.css
@@ -1,9 +1,6 @@
 div {
   position: absolute;
   margin: 0;
-  margin: 0;
-  margin: 0;
-  margin: 0;
   margin: 0 auto;
   margin: 0 2px 3px;
   color: rgba(0, 0, 0, 0.3);

--- a/test/types/compile.js
+++ b/test/types/compile.js
@@ -6,7 +6,7 @@ var fs = require('fs')
 fs.readdirSync('test/fixtures').forEach(function (file, index) {
   // Ignore anything not a less/css file.
   if (file.indexOf('css') === -1 && file.indexOf('less') === -1) {
-  	return
+    return
   }
 
   RECESS('test/fixtures/' + file, { compile: true, inlineImages: true  }, function (err, fat) {


### PR DESCRIPTION
Added another try/catch for tree.toCSS because parse errors were not captured by parent try/catch.

I'm not sure when or even if `less.Parser(options).parse` throws errors.

Also updated the way errors are logged; replaced custom error parser with `less.formatError`
