### PR TITLE
Proper anchor href formatting for fat's Twitter page

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,7 +157,7 @@ recess('./js/fat.less', { compile: true }, function (err, obj) {
 
   <h4 id="programmatic-api">Issues or Feedback</h4>
 
-   <p>If you have any problems, concerns, or just want to say hi please let me know by filing a <a href="https://github.com/twitter/recess">github issue here</a> or messaging me on twitter at <a href="https://twitter.com/fat">@fat</a>. Thanks!</p>
+   <p>If you have any problems, concerns, or just want to say hi please let me know by filing a <a href="https://github.com/twitter/recess">github issue here</a> or messaging me on twitter at <a href="//twitter.com/fat">@fat</a>. Thanks!</p>
 
   <hr>
   <p class="license">Code licensed under the <a href="http://www.apache.org/licenses/LICENSE-2.0" target="_blank">Apache License v2.0</a>. Documentation licensed under <a href="http://creativecommons.org/licenses/by/3.0/">CC BY 3.0</a>.</p>


### PR DESCRIPTION
Since it seems like such a silly thing to make a pull request/raise an issue for, I tried tweeting @fat about this earlier but he didn't reply back. You've gotta format the href for his twitter link with a protocol for GitHub pages otherwise it ends up as it is right now:

http://twitter.github.com/recess/twitter.com/fat

I'm sure that's not the nonsense y'all intended.
