### PR TITLE
border-image property is missing from the linter list

### DIFF
--- a/lib/lint/strict-property-order.js
+++ b/lib/lint/strict-property-order.js
@@ -112,6 +112,7 @@ var _ = require('underscore')
     , 'border-bottom'
     , 'border-left'
     , 'border-color'
+    , 'border-image'
     , 'border-top-color'
     , 'border-right-color'
     , 'border-bottom-color'


### PR DESCRIPTION
When linting a file with [border-image](http://www.w3.org/TR/2002/WD-css3-border-20021107/#the-border-image) set, I get 

> Unknown property name: "border-image"
