### PR TITLE
Fixed a problem where recess would fail if directories exist inside the ...

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -262,20 +262,24 @@ RECESS.prototype = {
 RECESS.RULES = {}
 
 fs.readdirSync(path.join(__dirname, 'lint')).forEach(function (name) {
+  var fullPath = path.join(__dirname, 'lint', name)
+  if(fs.lstatSync(fullPath).isDirectory()) return
   var camelName = name
     .replace(/(\-[a-z])/gi, function ($1) { return $1.toUpperCase().replace('-', '') })
     .replace(/\.js$/, '')
-  RECESS.RULES[camelName] = require(path.join(__dirname, 'lint', name))
+  RECESS.RULES[camelName] = require(fullPath)
 })
 
 // import compilers
 RECESS.COMPILERS = {}
 
 fs.readdirSync(path.join(__dirname, 'compile')).forEach(function (name) {
+  var fullPath = path.join(__dirname, 'compile', name)
+  if(fs.lstatSync(fullPath).isDirectory()) return
   var camelName = name
     .replace(/(\-[a-z])/gi, function ($1) { return $1.toUpperCase().replace('-', '') })
     .replace(/\.js$/, '')
-  RECESS.COMPILERS[camelName] = require(path.join(__dirname, 'compile', name))
+  RECESS.COMPILERS[camelName] = require(fullPath)
 })
 
 // export class


### PR DESCRIPTION
...lib/lint or the lib/compile directories. This breaks for SVN and CVS users who keep recess in their repos.
