### PR TITLE
Ending process with exit code of 1 for fatal error or validation failure

### DIFF
--- a/bin/recess
+++ b/bin/recess
@@ -59,7 +59,13 @@ options.cli = true
 
 
 // if not watch - run Recess
-if (!options.watch) return recess(paths, options)
+if (!options.watch) return recess(paths, options, function (err, instances) {
+  var fails = instances.reduce(function (prev, inst) {
+    return prev + inst.fails;
+  }, 0)
+
+  process.exit(err || fails ? 1 : 0);
+})
 
 // if options watch, but compile isn't set - make it happen
 if (options.watch && !options.compile && !options.compress) options.compile = true;

--- a/lib/core.js
+++ b/lib/core.js
@@ -227,7 +227,7 @@ RECESS.prototype = {
     if (failed) {
 
       // count errors
-      fails = util.countErrors(this.definitions)
+      this.fails = fails = util.countErrors(this.definitions)
 
       // log file overview
       this.log('FILE: ' + this.path.cyan)


### PR DESCRIPTION
This addresses issue #23 by calling `process.exit(code=1)` when either an error is passed to the callback, or any of the instances have any failures. (added `fails` count to each instance that matches the corresponding local var)
