### PR TITLE
Adding repository section to package.json to suppress warning from NPM.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
 , "description": "A simple, attractive code quality tool for CSS built on top of LESS"
 , "version": "1.1.6"
 , "author": "Jacob Thornton <jacob@twitter.com> (https://github.com/fat)"
+, "repository": { "type": "git", "url": "git://github.com/twitter/recess.git" }
 , "keywords": ["css", "lint"]
 , "licenses": [ { "type": "Apache-2.0", "url": "http://www.apache.org/licenses/LICENSE-2.0" } ]
 , "main": "./lib"


### PR DESCRIPTION
NPM emits a warning when the repository field is not defined in the `package.json` file:

```
npm WARN package.json recess@1.1.6 No repository field.
```

This pull request adds the repository field. :-)
