### PR TITLE
Prevent using less 1.4.0 beta. Fixes: #96

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 , "main": "./lib"
 , "homepage": "http://twitter.github.com/recess"
 , "engines": { "node": ">= 0.4.0" }
-, "dependencies": { "colors": ">= 0.3.0", "nopt": ">= 1.0.10", "underscore": ">= 1.2.1", "watch": ">= 0.5.1", "less": ">= 1.3.0" }
+, "dependencies": { "colors": ">= 0.3.0", "nopt": ">= 1.0.10", "underscore": ">= 1.2.1", "watch": ">= 0.5.1", "less": "~ 1.3.0" }
 , "directories": { "bin": "./bin" }
 , "scripts": { "test": "node test" }
 , "bin": { "recess": "./bin/recess" }


### PR DESCRIPTION
Using >= 1.3.0 currently results in installing less 1.4.0 which still in beta and it could lead to unexpected behavior. Switching to tilde version format instead.
