### PR TITLE
Use LESS "1.3.x" instead of ">= 1.3.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 , "main": "./lib"
 , "homepage": "http://twitter.github.com/recess"
 , "engines": { "node": ">= 0.4.0" }
-, "dependencies": { "colors": ">= 0.3.0", "nopt": ">= 1.0.10", "underscore": ">= 1.2.1", "watch": ">= 0.5.1", "less": ">= 1.3.0" }
+, "dependencies": { "colors": ">= 0.3.0", "nopt": ">= 1.0.10", "underscore": ">= 1.2.1", "watch": ">= 0.5.1", "less": "1.3.x" }
 , "directories": { "bin": "./bin" }
 , "scripts": { "test": "node test" }
 , "bin": { "recess": "./bin/recess" }


### PR DESCRIPTION
LESS 1.4.0 (beta) produces a unexpected error 

```
Running "recess:build" (recess) task
>> TypeError: Cannot call method 'map' of undefined
```

Producing all packages depending on recess to fail.

Related: https://github.com/twitter/bootstrap/issues/8088
