### PR TITLE
Removed space from LESS dependency version declaration in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 , "main": "./lib"
 , "homepage": "http://twitter.github.com/recess"
 , "engines": { "node": ">= 0.4.0" }
-, "dependencies": { "colors": ">= 0.3.0", "nopt": ">= 1.0.10", "underscore": ">= 1.2.1", "watch": ">= 0.5.1", "less": "~ 1.3.0" }
+, "dependencies": { "colors": ">= 0.3.0", "nopt": ">= 1.0.10", "underscore": ">= 1.2.1", "watch": ">= 0.5.1", "less": "~1.3.0" }
 , "directories": { "bin": "./bin" }
 , "scripts": { "test": "node test" }
 , "bin": { "recess": "./bin/recess" }


### PR DESCRIPTION
A space results in v1.3.0 instead of the intended version range(>=1.3.0 <1.4.0).
