### PR TITLE
jUnit-compatible output format.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ nbproject
 
 #node modules
 node_modules
+
+Gemfile.lock

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ OPTIONS
 - --format <format> - control the output format of errors:
   - --format text - the default format, shows errors and context
   - --format compact - show errors one-error-per-line, useful for IDE integration
+  - --format junit - generate error report in jUnit format, useful for CI integration
 - --noSummary - don't output the summary block for each file
 - --includePath - accepts an additional directory path to look for `@import`:ed LESS files in.
 - --stripColors - removes color from output (useful when logging)

--- a/lib/core.js
+++ b/lib/core.js
@@ -17,9 +17,15 @@ var _ = require('underscore')
   , fs = require('fs')
 
 // core class defintion
-function RECESS(path, options, callback) {
+function RECESS(path, options, log, formatter, callback) {
   this.path = path
-  this.output = []
+
+  this.log = function(string) { log.log(string); }
+  this.logForce = function(string) { log.logForce(string); }
+  this.output = log.output
+
+  this.formatter = formatter
+
   this.errors = []
   this.options = _.extend({}, RECESS.DEFAULTS, options)
   path && this.read()
@@ -31,17 +37,6 @@ RECESS.prototype = {
 
   constructor: RECESS
 
-, log: function (str, force) {
-
-    if (this.options.stripColors) str = str.stripColors
-
-    // if compiling only write with force flag
-    if (!this.options.compile || force) {
-      this.options.cli ? console.log(str) : this.output.push(str)
-    }
-
-  }
-
 , read: function () {
     var that = this
 
@@ -51,7 +46,7 @@ RECESS.prototype = {
       //  if err, exit with could not read message
       if (err) {
         that.errors.push(err)
-        that.log('Error reading file: '.red + String(that.path).grey + '\n', true)
+        that.logForce('Error reading file: '.red + String(that.path).grey + '\n')
         return that.callback && that.callback()
       }
 
@@ -85,21 +80,7 @@ RECESS.prototype = {
             // push to errors array
             that.errors.push(err)
 
-            if (err.type == 'Parse') {
-              // parse error
-              that.log("Parser error".red + (err.filename ? ' in ' + err.filename : '') + '\n')
-            } else {
-              // other exception
-              that.log(String(err.name).red + ": " + err.message + ' of ' + String(err.filename).yellow + '\n')
-            }
-
-            // if extract - then log it
-            err.extract && err.extract.forEach(function (line, index) {
-              that.log(util.padLine(err.line + index) + line)
-            })
-
-            // add extra line for readability after error log
-            that.log(" ")
+	    that.formatter.parserError(err)
 
             // exit with callback if present
             return that.callback && that.callback()
@@ -126,19 +107,11 @@ RECESS.prototype = {
         })
 
     } catch (err) {
-
       // less exploded trying to parse the file (╯°□°）╯︵ ┻━┻
       // push to errors array
       that.errors.push(err)
 
-      // log a message trying to explain why
-      that.log(
-          "Parse error".red
-        + ": "
-        + err.message
-        + " on line "
-        + util.getLine(err.index, this.data)
-      )
+      that.formatter.parseError(err, util.getLine(err.index, this.data))
 
       // exit with callback if present
       this.callback && this.callback()
@@ -176,7 +149,7 @@ RECESS.prototype = {
     css = css.replace(/[\n\s\r]*$/, '')
 
     // output css
-    this.log(css, true)
+    this.logForce(css)
 
     // callback and exit
     this.callback && this.callback()
@@ -231,36 +204,26 @@ RECESS.prototype = {
       fails = util.countErrors(this.definitions)
 
       if (!this.options.noSummary) {
-        // log file overview
-        this.log('FILE: ' + this.path.cyan)
-        this.log('STATUS: ' + 'Busted'.magenta)
-        this.log('FAILURES: ' + (fails + ' failure' + (fails > 1 ? 's' : '')).magenta + '\n')
-      }
-
-      if (this.options.format && this.options.format == 'compact') {
-        formatter = function (err) {
-          that.log(that.path + ':' + err.line + ':' + err.message)
-        }
-      } else {
-        formatter = function (err) {
-          that.log(err.message)
-          err.extract && that.log(err.extract + '\n')
-        }
+	this.formatter.summary(this.path, fails);
       }
 
       // iterate through each definition
       this.definitions.forEach(function (def) {
-
         // if there's an error, log the error and optional err.extract
         def.errors
           && def.errors.length
-          && def.errors.forEach(formatter)
+          && def.errors.forEach(function(e) {
+	    that.formatter.validationError(
+	      e,
+	      that.path,
+	      e.line
+	    );
+	  })
       })
 
     } else {
       // it was a success - let the user know!
-      this.log('FILE: ' + this.path.cyan)
-      this.log('STATUS: ' + 'Perfect!\n'.yellow)
+      this.formatter.summary(this.path, 0);
     }
 
     // callback and exit
@@ -291,3 +254,9 @@ fs.readdirSync(path.join(__dirname, 'compile')).forEach(function (name) {
 
 // export class
 module.exports = RECESS
+
+/*
+ * Local Variables:
+ * js-indent-level: 2
+ * End:
+ */

--- a/lib/core.js
+++ b/lib/core.js
@@ -86,7 +86,7 @@ RECESS.prototype = {
             // push to errors array
             that.errors.push(err)
 
-	    that.formatter.parserError(err)
+            that.formatter.parserError(err)
 
             // exit with callback if present
             return that.callback && that.callback()
@@ -210,7 +210,7 @@ RECESS.prototype = {
       fails = util.countErrors(this.definitions)
 
       if (!this.options.noSummary) {
-	this.formatter.summary(this.path, fails);
+        this.formatter.summary(this.path, fails);
       }
 
       // iterate through each definition
@@ -219,12 +219,12 @@ RECESS.prototype = {
         def.errors
           && def.errors.length
           && def.errors.forEach(function(e) {
-	    that.formatter.validationError(
-	      e,
-	      that.path,
-	      e.line
-	    );
-	  })
+            that.formatter.validationError(
+              e,
+              that.path,
+              e.line
+            );
+          })
       })
 
     } else {

--- a/lib/core.js
+++ b/lib/core.js
@@ -15,12 +15,18 @@ var _ = require('underscore')
   , util = require('./util')
   , path = require('path')
   , fs = require('fs')
+  , formatterFactory = require('./formatters/factory')
 
 // core class defintion
-function RECESS(path, options, log, formatter, callback) {
+function RECESS(path, options, callback, formatter) {
+  if (!formatter) {
+    formatter = formatterFactory(options || {});
+  };
+  var log = formatter.logger;
+
   this.path = path
 
-  this.log = function(string) { log.log(string); }
+  this.log = function(string, force) { force ? log.logForce(string) : log.log(string); }
   this.logForce = function(string) { log.logForce(string); }
   this.output = log.output
 

--- a/lib/formatters/compact.js
+++ b/lib/formatters/compact.js
@@ -1,0 +1,58 @@
+'use strict'
+
+function CompactFormatter(log) {
+  this.log = function(string) { log.log(string); }
+}
+
+CompactFormatter.prototype = {
+  summary: function(path, fails) {
+    // No summary output in compact mode
+  },
+
+  startFile: function(path) {
+  },
+
+  parserError: function(err) {
+    if (err.type == 'Parse') {
+      // parse error
+      this.log("Parser error".red + (err.filename ? ' in ' + err.filename : '') + '\n')
+    } else {
+      // other exception
+      this.log(String(err.name).red + ": " + err.message + ' of ' + String(err.filename).yellow + '\n')
+    }
+
+    // if extract - then log it
+    err.extract && err.extract.forEach(function (line, index) {
+      this.log(util.padLine(err.line + index) + line)
+    })
+
+    // add extra line for readability after error log
+    this.log(" ")
+  },
+
+  parseError: function(err, line) {
+    // log a message trying to explain why
+    this.log(
+      "Parse error".red
+        + ": "
+        + err.message
+        + " on line "
+        + line
+    );
+  },
+
+  validationError: function(err, path) {
+    this.log(path + ':' + err.line + ':' + err.message)
+  },
+
+  complete: function() {
+  }
+}
+
+module.exports = CompactFormatter;
+
+/*
+ * Local Variables:
+ * js-indent-level: 2
+ * End:
+ */

--- a/lib/formatters/compact.js
+++ b/lib/formatters/compact.js
@@ -1,6 +1,7 @@
 'use strict'
 
 function CompactFormatter(log) {
+  this.logger = log;
   this.log = function(string) { log.log(string); }
 }
 

--- a/lib/formatters/factory.js
+++ b/lib/formatters/factory.js
@@ -1,0 +1,34 @@
+'use strict'
+
+var FormatterText = require('./text')
+  , FormatterCompact = require('./compact')
+  , FormatterJUnit = require('./junit')
+  , Logger = require('../logger')
+
+function formatterFactory(options) {
+  var log = new Logger(options);
+  var formatter;
+
+  switch (options.format) {
+  case 'compact':
+    formatter = new FormatterCompact(log);
+    break;
+  case 'junit':
+    formatter = new FormatterJUnit(log);
+    break;
+  case 'text':
+  default:
+    formatter = new FormatterText(log);
+    break;
+  };
+
+  return formatter;
+}
+
+module.exports = formatterFactory;
+
+/*
+ * Local Variables:
+ * js-indent-level: 2
+ * End:
+ */

--- a/lib/formatters/junit.js
+++ b/lib/formatters/junit.js
@@ -18,18 +18,15 @@ JUnitFormatter.prototype = {
   },
 
   parserError: function(err) {
-    this.errors[this.currentFile] = this.errors[this.currentFile] || []
-    this.errors[this.currentFile].push({ err: err, path: this.currentFile, line: err.line})
+    this.addError({ err: err, path: this.currentFile, line: err.line})
   },
 
   parseError: function(err, line) {
-    this.errors[this.currentFile] = this.errors[this.currentFile] || []
-    this.errors[this.currentFile].push({ err: err, path: this.currentFile, line: line})
+    this.addError({ err: err, path: this.currentFile, line: line})
   },
 
   validationError: function(err, path, line) {
-    this.errors[this.currentFile] = this.errors[this.currentFile] || [];
-    this.errors[this.currentFile].push({ err: err, path: this.currentFile, line: line})
+    this.addError({ err: err, path: this.currentFile, line: line})
   },
 
   complete: function() {
@@ -55,6 +52,11 @@ JUnitFormatter.prototype = {
     };
 
     this.log(doc.toString());
+  },
+
+  addError: function(data) {
+    this.errors[this.currentFile] = this.errors[this.currentFile] || []
+    this.errors[this.currentFile].push(data)
   }
 }
 

--- a/lib/formatters/junit.js
+++ b/lib/formatters/junit.js
@@ -18,37 +18,18 @@ JUnitFormatter.prototype = {
   },
 
   parserError: function(err) {
-    if (err.type == 'Parse') {
-      // parse error
-      this.log("Parser error".red + (err.filename ? ' in ' + err.filename : '') + '\n')
-    } else {
-      // other exception
-      this.log(String(err.name).red + ": " + err.message + ' of ' + String(err.filename).yellow + '\n')
-    }
-
-    // if extract - then log it
-    err.extract && err.extract.forEach(function (line, index) {
-      this.log(util.padLine(err.line + index) + line)
-    })
-
-    // add extra line for readability after error log
-    this.log(" ")
+    this.errors[this.currentFile] = this.errors[this.currentFile] || []
+    this.errors[this.currentFile].push({ err: err, path: this.currentFile, line: err.line})
   },
 
   parseError: function(err, line) {
-    // log a message trying to explain why
-    this.log(
-      "Parse error".red
-        + ": "
-        + err.message
-        + " on line "
-        + line
-    );
+    this.errors[this.currentFile] = this.errors[this.currentFile] || []
+    this.errors[this.currentFile].push({ err: err, path: this.currentFile, line: line})
   },
 
   validationError: function(err, path, line) {
     this.errors[this.currentFile] = this.errors[this.currentFile] || [];
-    this.errors[this.currentFile].push({ err: err, path: path, line: line})
+    this.errors[this.currentFile].push({ err: err, path: this.currentFile, line: line})
   },
 
   complete: function() {

--- a/lib/formatters/junit.js
+++ b/lib/formatters/junit.js
@@ -3,6 +3,7 @@
 var libxml = require("libxmljs");
 
 function JUnitFormatter(log) {
+  this.logger = log;
   this.log = function(string) { log.log(string); }
   this.errors = {};
   this.currentFile = null;

--- a/lib/formatters/junit.js
+++ b/lib/formatters/junit.js
@@ -1,0 +1,86 @@
+'use strict'
+
+var libxml = require("libxmljs");
+
+function JUnitFormatter(log) {
+  this.log = function(string) { log.log(string); }
+  this.errors = {};
+  this.currentFile = null;
+}
+
+JUnitFormatter.prototype = {
+  summary: function(path, fails) {
+    // No summary output in compact mode
+  },
+
+  startFile: function(path) {
+    this.currentFile = path;
+  },
+
+  parserError: function(err) {
+    if (err.type == 'Parse') {
+      // parse error
+      this.log("Parser error".red + (err.filename ? ' in ' + err.filename : '') + '\n')
+    } else {
+      // other exception
+      this.log(String(err.name).red + ": " + err.message + ' of ' + String(err.filename).yellow + '\n')
+    }
+
+    // if extract - then log it
+    err.extract && err.extract.forEach(function (line, index) {
+      this.log(util.padLine(err.line + index) + line)
+    })
+
+    // add extra line for readability after error log
+    this.log(" ")
+  },
+
+  parseError: function(err, line) {
+    // log a message trying to explain why
+    this.log(
+      "Parse error".red
+        + ": "
+        + err.message
+        + " on line "
+        + line
+    );
+  },
+
+  validationError: function(err, path, line) {
+    this.errors[this.currentFile] = this.errors[this.currentFile] || [];
+    this.errors[this.currentFile].push({ err: err, path: path, line: line})
+  },
+
+  complete: function() {
+    var doc = new libxml.Document();
+    var suiteNode = doc
+      .node("testsuite")
+      .attr("name", "RECESS")
+      .attr("tests", this.errors.length)
+      .attr("errors", this.errors.length)
+      .attr("timestamp", new Date().toISOString());
+
+    for (var file in this.errors) {
+      var errors = this.errors[file];
+      var caseNode = suiteNode.node("testcase")
+	.attr("name", file);
+
+      errors.forEach(function(errorData) {
+	caseNode
+	  .node("error")
+	  .attr("type", errorData.err.type.stripColors)
+	  .attr("message", errorData.err.message.stripColors + " at line " + errorData.line)
+      });
+    };
+
+    this.log(doc.toString());
+  }
+}
+
+module.exports = JUnitFormatter;
+
+/*
+ * Local Variables:
+ * js-indent-level: 2
+ * End:
+ */

--- a/lib/formatters/text.js
+++ b/lib/formatters/text.js
@@ -1,6 +1,7 @@
 'use strict'
 
 function TextFormatter(log) {
+  this.logger = log;
   this.log = function(string) { log.log(string); }
 }
 

--- a/lib/formatters/text.js
+++ b/lib/formatters/text.js
@@ -1,0 +1,67 @@
+'use strict'
+
+function TextFormatter(log) {
+  this.log = function(string) { log.log(string); }
+}
+
+TextFormatter.prototype = {
+  summary: function(path, fails) {
+    // log file overview
+    this.log('FILE: ' + path.cyan)
+
+    if (fails) {
+      this.log('STATUS: ' + 'Busted'.magenta)
+      this.log('FAILURES: ' + (fails + ' failure' + (fails > 1 ? 's' : '')).magenta + '\n')
+    } else {
+      this.log('STATUS: ' + 'Perfect!\n'.yellow)
+    };
+  },
+
+  startFile: function(path) {
+  },
+
+  parserError: function(err) {
+    if (err.type == 'Parse') {
+      // parse error
+      this.log("Parser error".red + (err.filename ? ' in ' + err.filename : '') + '\n')
+    } else {
+      // other exception
+      this.log(String(err.name).red + ": " + err.message + ' of ' + String(err.filename).yellow + '\n')
+    }
+
+    // if extract - then log it
+    err.extract && err.extract.forEach(function (line, index) {
+      this.log(util.padLine(err.line + index) + line)
+    })
+
+    // add extra line for readability after error log
+    this.log(" ")
+  },
+
+  parseError: function(err, line) {
+    // log a message trying to explain why
+    this.log(
+      "Parse error".red
+        + ": "
+        + err.message
+        + " on line "
+        + line
+    );
+  },
+
+  validationError: function(err, path) {
+    this.log(err.message)
+    err.extract && this.log(err.extract + '\n')
+  },
+
+  complete: function() {
+  }
+}
+
+module.exports = TextFormatter;
+
+/*
+ * Local Variables:
+ * js-indent-level: 2
+ * End:
+ */

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,10 +12,7 @@
 // require core
 var RECESS = require('./core')
   , colors = require('colors')
-  , FormatterJUnit = require('./formatters/junit')
-  , FormatterText = require('./formatters/text')
-  , FormatterCompact = require('./formatters/compact')
-  , Logger = require('./logger')
+  , formatterFactory = require('./formatters/factory')
 
 // define main export
 module.exports = function (paths, options, callback) {
@@ -47,30 +44,15 @@ module.exports = function (paths, options, callback) {
     console.log(message)
   }
 
-  // Logger
-  var log = new Logger(options);
-
   // Create an instance of the output formatter selected by the user
-  var formatter;
-  switch (options.format) {
-  case 'compact':
-    formatter = new FormatterCompact(log);
-    break;
-  case 'junit':
-    formatter = new FormatterJUnit(log);
-    break;
-  case 'text':
-  default:
-    formatter = new FormatterText(log);
-    break;
-  }
+  var formatter = formatterFactory(options);
 
   // for each path, create a new RECESS instance
   function recess(init, path, err) {
     if (path = paths.shift()) {
-      log.output = [];
+      formatter.logger.output = [];
       formatter.startFile(path);
-      return instances.push(new RECESS(path, options, log, formatter, recess))
+      return instances.push(new RECESS(path, options, recess, formatter))
     }
 
     // map/filter for errors

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,10 @@
 // require core
 var RECESS = require('./core')
   , colors = require('colors')
+  , FormatterJUnit = require('./formatters/junit')
+  , FormatterText = require('./formatters/text')
+  , FormatterCompact = require('./formatters/compact')
+  , Logger = require('./logger')
 
 // define main export
 module.exports = function (paths, options, callback) {
@@ -37,16 +41,36 @@ module.exports = function (paths, options, callback) {
   options.format && (options.format == 'compact') && (options.noSummary = true)
 
   // if not compiling, let user know which files will be linted
-  if (!options.compile && options.cli && !options.noSummary) {
+  if (!options.compile && options.cli && !options.noSummary && options.format != 'junit') {
     message = "\nAnalyzing the following files: " + ((paths + '').replace(/,/g, ', ') + '\n').grey
     options.stripColors && (message = message.stripColors)
     console.log(message)
   }
 
+  // Logger
+  var log = new Logger(options);
+
+  // Create an instance of the output formatter selected by the user
+  var formatter;
+  switch (options.format) {
+  case 'compact':
+    formatter = new FormatterCompact(log);
+    break;
+  case 'junit':
+    formatter = new FormatterJUnit(log);
+    break;
+  case 'text':
+  default:
+    formatter = new FormatterText(log);
+    break;
+  }
+
   // for each path, create a new RECESS instance
   function recess(init, path, err) {
     if (path = paths.shift()) {
-      return instances.push(new RECESS(path, options, recess))
+      log.output = [];
+      formatter.startFile(path);
+      return instances.push(new RECESS(path, options, log, formatter, recess))
     }
 
     // map/filter for errors
@@ -63,6 +87,8 @@ module.exports = function (paths, options, callback) {
 
     //callback
     callback && callback(err, instances)
+
+    formatter.complete();
   }
 
   // start processing paths
@@ -102,3 +128,9 @@ module.exports.docs = function () {
   console.log("\nEXAMPLE:\n\n" + "  $".grey + " recess".cyan + " ./bootstrap.css ".yellow + "--noIDs false\n".grey)
   console.log('GENERAL HELP: ' + 'http://git.io/recess\n'.yellow)
 }
+
+/*
+ * Local Variables:
+ * js-indent-level: 2
+ * End:
+ */

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,0 +1,28 @@
+'use strict'
+
+function Logger(options) {
+  this.options = options;
+  this.output = [];
+}
+
+Logger.prototype = {
+  log: function (str) {
+    // if compiling only write with force flag
+    if (!this.options.compile) {
+      this.logForce(str);
+    }
+  },
+
+  logForce: function(str) {
+    if (this.options.stripColors) str = str.stripColors
+
+    this.options.cli ? console.log(str) : this.output.push(str)
+  }
+};
+
+module.exports = Logger;
+/*
+ * Local Variables:
+ * js-indent-level: 2
+ * End:
+ */

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -7,7 +7,6 @@ function Logger(options) {
 
 Logger.prototype = {
   log: function (str) {
-    // if compiling only write with force flag
     if (!this.options.compile) {
       this.logForce(str);
     }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
 , "main": "./lib"
 , "homepage": "http://twitter.github.com/recess"
 , "engines": { "node": ">= 0.4.0" }
-, "dependencies": { "colors": ">= 0.3.0", "nopt": ">= 1.0.10", "underscore": ">= 1.2.1", "watch": ">= 0.5.1", "less": "~1.3.0" }
+, "dependencies": { "colors": ">= 0.3.0", "nopt": ">= 1.0.10", "underscore": ">= 1.2.1", "watch": ">= 0.5.1", "less": "~1.3.0",
+		    "libxmljs": "~0.8.1" }
 , "directories": { "bin": "./bin" }
 , "scripts": { "test": "node test" }
 , "bin": { "recess": "./bin/recess" }

--- a/test/Gemfile
+++ b/test/Gemfile
@@ -1,0 +1,2 @@
+gem 'guard'
+gem 'guard-cucumber'

--- a/test/Gemfile
+++ b/test/Gemfile
@@ -1,2 +1,4 @@
 gem 'guard'
 gem 'guard-cucumber'
+gem 'nokogiri'
+gem 'rspec'

--- a/test/Guardfile
+++ b/test/Guardfile
@@ -1,0 +1,8 @@
+# A sample Guardfile
+# More info at https://github.com/guard/guard#readme
+
+guard :cucumber do
+  watch(%r{^test/features/.+/\.rb$})
+  watch(%r{^test/features/.+/\.feature$})
+end
+

--- a/test/features/format_compact.feature
+++ b/test/features/format_compact.feature
@@ -28,3 +28,35 @@ a {
   Correct order below:
 
     """
+
+  Scenario: RECESS generates output in compact format for several files
+
+    Given the first input file contains the following CSS
+    """
+a {
+  text-decoration: underline;
+}
+
+.test.test2 {
+  color: white;
+  width: 33;
+  height: 12px;
+}
+    """
+    Given the second input file contains the following CSS
+    """
+#sample-id {
+    text-decoration: underline;
+}
+    """
+    And I run recess with "--format compact --stripColors" parameters and two input files
+
+    Then output should be
+    """
+%{path1}:5:Element selectors should not be overqualified
+%{path1}:6:Incorrect property order for rule ".test.test2"
+
+  Correct order below:
+
+%{path2}:1:Id's should not be styled
+    """

--- a/test/features/format_compact.feature
+++ b/test/features/format_compact.feature
@@ -1,0 +1,30 @@
+Feature: compact output format
+
+  In order to simplify integration with IDEs
+  As a developer
+  I want to be able to generate test results in compact text format
+
+  Scenario: RECESS generates output in compact format
+
+    Given the input file contains the following CSS
+    """
+a {
+  text-decoration: underline;
+}
+
+.test.test2 {
+  color: white;
+  width: 33;
+  height: 12px;
+}
+    """
+    And I run recess with "--format compact --stripColors" parameters
+
+    Then output should be
+    """
+%{path}:5:Element selectors should not be overqualified
+%{path}:6:Incorrect property order for rule ".test.test2"
+
+  Correct order below:
+
+    """

--- a/test/features/format_junit.feature
+++ b/test/features/format_junit.feature
@@ -21,6 +21,36 @@ a {
     And I run recess with "--format junit" parameters
 
     Then output should be in jUnit format
+    And generated jUnit report should contain 1 testcase
     And generated jUnit report should contain 2 errors
     And error #1 should be "Element selectors should not be overqualified" in line 5
     And error #2 should be "Incorrect property order" in line 6
+
+  Scenario: RECESS generates output in jUnit format for several files
+
+    Given the first input file contains the following CSS
+    """
+a {
+  text-decoration: underline;
+}
+
+.test.test2 {
+  color: white;
+  width: 33;
+  height: 12px;
+}
+    """
+    Given the second input file contains the following CSS
+    """
+#sample-id {
+    text-decoration: underline;
+}
+    """
+    And I run recess with "--format junit" parameters and two input files
+
+    Then output should be in jUnit format
+    And generated jUnit report should contain 2 testcases
+    And generated jUnit report should contain 3 errors
+    And error #1 should be "Element selectors should not be overqualified" in first file line 5
+    And error #2 should be "Incorrect property order" in first file line 6
+    And error #3 should be "Id's should not be styled" in second file line 1

--- a/test/features/format_junit.feature
+++ b/test/features/format_junit.feature
@@ -21,6 +21,6 @@ a {
     And I run recess with "--format junit" parameters
 
     Then output should be in jUnit format
-    And generated jUnit report should contain 2 failures
-    And failure #1 should be "Element selectors should not be overqualified" in line 5
-    And failure #2 should be "Incorrect property order" in line 6
+    And generated jUnit report should contain 2 errors
+    And error #1 should be "Element selectors should not be overqualified" in line 5
+    And error #2 should be "Incorrect property order" in line 6

--- a/test/features/format_junit.feature
+++ b/test/features/format_junit.feature
@@ -1,0 +1,26 @@
+Feature: jUnit output format
+
+  In order do simplify integration with CI servers
+  As a developer
+  I want to be able to generate test results in jUnit XML format understood by CI servers
+
+  Scenario: RECESS generates output in jUnit format
+
+    Given the input file contains the following CSS
+    """
+a {
+  text-decoration: underline;
+}
+
+.test.test2 {
+  color: white;
+  width: 33;
+  height: 12px;
+}
+    """
+    And I run recess with "--format junit" parameters
+
+    Then output should be in jUnit format
+    And generated jUnit report should contain 2 failures
+    And failure #1 should be "Element selectors should not be overqualified" in line 5
+    And failure #2 should be "Incorrect property order" in line 6

--- a/test/features/format_junit.feature
+++ b/test/features/format_junit.feature
@@ -54,3 +54,17 @@ a {
     And error #1 should be "Element selectors should not be overqualified" in first file line 5
     And error #2 should be "Incorrect property order" in first file line 6
     And error #3 should be "Id's should not be styled" in second file line 1
+
+ Scenario: RECESS handles CSS parse errors gracefully when outputting jUnit data
+
+    Given the input file contains the following CSS
+    """
+a {
+  text-decoration: underline;
+    """
+    And I run recess with "--format junit" parameters
+
+    Then output should be in jUnit format
+    And generated jUnit report should contain 1 testcase
+    And generated jUnit report should contain 1 error
+    And error #1 should be "missing closing `}`" in line 2

--- a/test/features/format_junit.feature
+++ b/test/features/format_junit.feature
@@ -1,6 +1,6 @@
 Feature: jUnit output format
 
-  In order do simplify integration with CI servers
+  In order to simplify integration with CI servers
   As a developer
   I want to be able to generate test results in jUnit XML format understood by CI servers
 

--- a/test/features/format_text.feature
+++ b/test/features/format_text.feature
@@ -41,3 +41,53 @@ Correct order below:
        8.  color: white;
 
     """
+
+  Scenario: RECESS generates output in standard format for several files
+
+    Given the first input file contains the following CSS
+    """
+a {
+  text-decoration: underline;
+}
+
+.test.test2 {
+  color: white;
+  width: 33;
+  height: 12px;
+}
+    """
+    Given the second input file contains the following CSS
+    """
+#sample-id {
+    text-decoration: underline;
+}
+    """
+    And I run recess with "--format text --stripColors" parameters and two input files
+
+    Then output should be
+    """
+Analyzing the following files: %{path1}, %{path2}
+
+FILE: %{path1}
+STATUS: Busted
+FAILURES: 2 failures
+
+Element selectors should not be overqualified
+       5. .test.test2
+
+Incorrect property order for rule ".test.test2"
+
+  Correct order below:
+
+       6.  width: 33;
+       7.  height: 12px;
+       8.  color: white;
+
+FILE: %{path2}
+STATUS: Busted
+FAILURES: 1 failure
+
+Id's should not be styled
+       1. #sample-id
+
+    """

--- a/test/features/format_text.feature
+++ b/test/features/format_text.feature
@@ -1,0 +1,43 @@
+Feature: text output format
+
+  In order to easily read and understand recess report
+  As a developer
+  I want to be able to generate test results in human-readable output format
+
+  Scenario: RECESS generates output in text format
+
+    Given the input file contains the following CSS
+    """
+a {
+  text-decoration: underline;
+}
+
+.test.test2 {
+  color: white;
+  width: 33;
+  height: 12px;
+}
+    """
+    And I run recess with "--format text --stripColors" parameters
+
+    Then output should be
+    """
+
+Analyzing the following files: %{path}
+
+FILE: %{path}
+STATUS: Busted
+FAILURES: 2 failures
+
+Element selectors should not be overqualified
+       5. .test.test2
+
+Incorrect property order for rule ".test.test2"
+
+Correct order below:
+
+       6.  width: 33;
+       7.  height: 12px;
+       8.  color: white;
+
+    """

--- a/test/features/step_definitions/junit_steps.rb
+++ b/test/features/step_definitions/junit_steps.rb
@@ -21,3 +21,28 @@ Then(/^error \#(\d+) should be "(.*?)" in line (\d+)$/) do |error_number, name, 
   expect(error.attr("message")).to match name
   expect(error.attr("message")).to match /line #{line}/
 end
+
+Then(/^generated jUnit report should contain (\d+) testcases?$/) do |num_cases|
+  doc = Nokogiri::XML(@stdout)
+  expect(doc.xpath("count(//testcase)").to_i).to eq num_cases.to_i
+end
+
+Then(/^error \#(\d+) should be "(.*?)" in first file line (\d+)$/) do |error_number, name, line|
+  doc = Nokogiri::XML(@stdout)
+  error = doc.xpath("//error")[error_number.to_i - 1]
+
+  expect(error).to_not be_nil
+  expect(error.attr("message")).to match name
+  expect(error.attr("message")).to match /line #{line}/
+  expect(error.parent().attr("name")).to eq @input_file_1.path
+end
+
+Then(/^error \#(\d+) should be "(.*?)" in second file line (\d+)$/) do |error_number, name, line|
+  doc = Nokogiri::XML(@stdout)
+  error = doc.xpath("//error")[error_number.to_i - 1]
+
+  expect(error).to_not be_nil
+  expect(error.attr("message")).to match name
+  expect(error.attr("message")).to match /line #{line}/
+  expect(error.parent().attr("name")).to eq @input_file_2.path
+end

--- a/test/features/step_definitions/junit_steps.rb
+++ b/test/features/step_definitions/junit_steps.rb
@@ -8,7 +8,7 @@ Then(/^output should be in jUnit format$/) do
 EOF
 end
 
-Then(/^generated jUnit report should contain (\d+) errors$/) do |num_errors|
+Then(/^generated jUnit report should contain (\d+) errors?$/) do |num_errors|
   doc = Nokogiri::XML(@stdout)
   expect(doc.xpath("count(//error)").to_i).to eq num_errors.to_i
 end

--- a/test/features/step_definitions/junit_steps.rb
+++ b/test/features/step_definitions/junit_steps.rb
@@ -1,0 +1,11 @@
+Then(/^output should be in jUnit format$/) do
+  pending # express the regexp above with the code you wish you had
+end
+
+Then(/^generated jUnit report should contain (\d+) failures$/) do |arg1|
+  pending # express the regexp above with the code you wish you had
+end
+
+Then(/^failure \#(\d+) should be "(.*?)" in line (\d+)$/) do |arg1, arg2, arg3|
+  pending # express the regexp above with the code you wish you had
+end

--- a/test/features/step_definitions/junit_steps.rb
+++ b/test/features/step_definitions/junit_steps.rb
@@ -1,11 +1,23 @@
 Then(/^output should be in jUnit format$/) do
-  pending # express the regexp above with the code you wish you had
+  xsd = Nokogiri::XML::Schema(File.read(path_to_junit_xsd))
+  doc = Nokogiri::XML(@stdout)
+  expect(xsd.valid?(doc)).to be_true, <<EOF
+=== jUnit.xsd validation failed for the following output: ===
+#{@stdout}
+=============================================================
+EOF
 end
 
-Then(/^generated jUnit report should contain (\d+) failures$/) do |arg1|
-  pending # express the regexp above with the code you wish you had
+Then(/^generated jUnit report should contain (\d+) errors$/) do |num_errors|
+  doc = Nokogiri::XML(@stdout)
+  expect(doc.xpath("count(//error)").to_i).to eq num_errors.to_i
 end
 
-Then(/^failure \#(\d+) should be "(.*?)" in line (\d+)$/) do |arg1, arg2, arg3|
-  pending # express the regexp above with the code you wish you had
+Then(/^error \#(\d+) should be "(.*?)" in line (\d+)$/) do |error_number, name, line|
+  doc = Nokogiri::XML(@stdout)
+  error = doc.xpath("//error")[error_number.to_i - 1]
+
+  expect(error).to_not be_nil
+  expect(error.attr("message")).to match name
+  expect(error.attr("message")).to match /line #{line}/
 end

--- a/test/features/step_definitions/recess_steps.rb
+++ b/test/features/step_definitions/recess_steps.rb
@@ -1,11 +1,8 @@
 Given(/^the input file contains the following CSS$/) do |string|
-  pending # express the regexp above with the code you wish you had
+  @input_file = Tempfile.new('junit-test-css')
+  @input_file.write(string)
 end
 
 Given(/^I run recess with "(.*?)" parameters$/) do |arg1|
-  pending # express the regexp above with the code you wish you had
-end
-
-Then(/^it should generate "(.*?)" file$/) do |arg1|
-  pending # express the regexp above with the code you wish you had
+  @stdout = `../bin/recess #{@input_file.path} #{arg1}`
 end

--- a/test/features/step_definitions/recess_steps.rb
+++ b/test/features/step_definitions/recess_steps.rb
@@ -4,10 +4,34 @@ Given(/^the input file contains the following CSS$/) do |string|
   @input_file.close
 end
 
+Given(/^the first input file contains the following CSS$/) do |string|
+  @input_file_1 = Tempfile.new('junit-test-css')
+  @input_file_1.write(string)
+  @input_file_1.close
+end
+
+Given(/^the second input file contains the following CSS$/) do |string|
+  @input_file_2 = Tempfile.new('junit-test-css')
+  @input_file_2.write(string)
+  @input_file_2.close
+end
+
 Given(/^I run recess with "(.*?)" parameters$/) do |arg1|
   @stdout = `../bin/recess #{@input_file.path} #{arg1}`
 end
 
+Given(/^I run recess with "(.*?)" parameters and two input files$/) do |arg1|
+  @stdout = `../bin/recess #{@input_file_1.path} #{@input_file_2.path} #{arg1}`
+end
+
 Then(/^output should be$/) do |string|
-  expect(@stdout).to match_lines (string % { :path => @input_file.path } )
+  interpolated = string % {
+    :name => @input_file && File.basename(@input_file.path) ,
+    :path => @input_file && @input_file.path,
+    :name1 => @input_file_1 && File.basename(@input_file_1.path),
+    :path1 => @input_file_1 && @input_file_1.path,
+    :name2 => @input_file_2 && File.basename(@input_file_2.path),
+    :path2 => @input_file_2 && @input_file_2.path
+  }
+  expect(@stdout).to match_lines(interpolated)
 end

--- a/test/features/step_definitions/recess_steps.rb
+++ b/test/features/step_definitions/recess_steps.rb
@@ -1,8 +1,13 @@
 Given(/^the input file contains the following CSS$/) do |string|
   @input_file = Tempfile.new('junit-test-css')
   @input_file.write(string)
+  @input_file.close
 end
 
 Given(/^I run recess with "(.*?)" parameters$/) do |arg1|
   @stdout = `../bin/recess #{@input_file.path} #{arg1}`
+end
+
+Then(/^output should be$/) do |string|
+  expect(@stdout).to match_lines (string % { :path => @input_file.path } )
 end

--- a/test/features/step_definitions/recess_steps.rb
+++ b/test/features/step_definitions/recess_steps.rb
@@ -1,0 +1,11 @@
+Given(/^the input file contains the following CSS$/) do |string|
+  pending # express the regexp above with the code you wish you had
+end
+
+Given(/^I run recess with "(.*?)" parameters$/) do |arg1|
+  pending # express the regexp above with the code you wish you had
+end
+
+Then(/^it should generate "(.*?)" file$/) do |arg1|
+  pending # express the regexp above with the code you wish you had
+end

--- a/test/features/support/JUnit.xsd
+++ b/test/features/support/JUnit.xsd
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+    <xs:element name="failure">
+        <xs:complexType mixed="true">
+            <xs:attribute name="type" type="xs:string" use="optional"/>
+            <xs:attribute name="message" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="error">
+        <xs:complexType mixed="true">
+            <xs:attribute name="type" type="xs:string" use="optional"/>
+            <xs:attribute name="message" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="properties">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="property" maxOccurs="unbounded"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="property">
+        <xs:complexType>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="value" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="skipped" type="xs:string"/>
+    <xs:element name="system-err" type="xs:string"/>
+    <xs:element name="system-out" type="xs:string"/>
+
+    <xs:element name="testcase">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="skipped" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="error" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="failure" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="system-out" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="system-err" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="assertions" type="xs:string" use="optional"/>
+            <xs:attribute name="time" type="xs:string" use="optional"/>
+            <xs:attribute name="classname" type="xs:string" use="optional"/>
+            <xs:attribute name="status" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="testsuite">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="properties" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="testcase" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="system-out" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="system-err" minOccurs="0" maxOccurs="1"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="tests" type="xs:string" use="required"/>
+            <xs:attribute name="failures" type="xs:string" use="optional"/>
+            <xs:attribute name="errors" type="xs:string" use="optional"/>
+            <xs:attribute name="time" type="xs:string" use="optional"/>
+            <xs:attribute name="disabled" type="xs:string" use="optional"/>
+            <xs:attribute name="skipped" type="xs:string" use="optional"/>
+            <xs:attribute name="timestamp" type="xs:string" use="optional"/>
+            <xs:attribute name="hostname" type="xs:string" use="optional"/>
+            <xs:attribute name="id" type="xs:string" use="optional"/>
+            <xs:attribute name="package" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="testsuites">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="testsuite" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="optional"/>
+            <xs:attribute name="time" type="xs:string" use="optional"/>
+            <xs:attribute name="tests" type="xs:string" use="optional"/>
+            <xs:attribute name="failures" type="xs:string" use="optional"/>
+            <xs:attribute name="disabled" type="xs:string" use="optional"/>
+            <xs:attribute name="errors" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+
+</xs:schema>

--- a/test/features/support/env.rb
+++ b/test/features/support/env.rb
@@ -1,3 +1,4 @@
+require 'tempfile'
 require 'nokogiri'
 require 'rspec/expectations'
 

--- a/test/features/support/env.rb
+++ b/test/features/support/env.rb
@@ -1,0 +1,10 @@
+require 'nokogiri'
+require 'rspec/expectations'
+
+def path_to_junit_xsd
+  "features/support/JUnit.xsd"
+end
+
+def path_to_recess_executable
+  "../bin/recess"
+end

--- a/test/features/support/matchers.rb
+++ b/test/features/support/matchers.rb
@@ -1,0 +1,19 @@
+RSpec::Matchers.define :match_lines do |expected|
+  def normalize(string)
+    string.lines.map{ |l| l.strip }.reject {|l| l.empty? } .join("\n")
+  end
+
+  match do |actual|
+    normalized_actual = normalize(actual)
+    normalized_expected = normalize(expected)
+
+    expect(normalized_actual).to eq normalized_expected
+  end
+
+  failure_message_for_should do |actual|
+    normalized_actual = normalize(actual)
+    normalized_expected = normalize(expected)
+
+    expect(normalized_actual).to eq normalized_expected
+  end
+end

--- a/test/types/lint.js
+++ b/test/types/lint.js
@@ -1,6 +1,5 @@
 var assert = require('assert')
   , RECESS = require('../../lib')
-  , Logger = require('../../lib/logger')
   , colors = require('colors')
   , fs = require('fs')
   , noop = function () {}
@@ -16,16 +15,13 @@ var assert = require('assert')
 
   console.log = function (string) { loggedStr = string }
 
-  var options = { cli: true }
-  withOutCompile = new RECESS.Constructor(null, options, new Logger(options))
+  withOutCompile = new RECESS.Constructor(null, { cli: true })
   withOutCompile.log('first')
   assert.equal(loggedStr, 'first', 'console.log was not called when compile was true')
-
-  options = { compile: true, cli: true};
-  withCompile = new RECESS.Constructor(false, options, new Logger(options))
+  withCompile = new RECESS.Constructor(false, { compile: true, cli: true})
   withCompile.log('second')
   assert.equal(loggedStr, 'first', 'console.log was not called when compile was true')
-  withCompile.logForce('third')
+  withCompile.log('third', true)
   assert.equal(loggedStr, 'third', 'console.log was called when force was was true')
 
   console.log = log
@@ -40,13 +36,10 @@ var assert = require('assert')
 
   console.log = function (string) { loggedStr = string }
 
-  var options = { cli: true }
-  cliInstance = new RECESS.Constructor(null, options, new Logger(options))
+  cliInstance = new RECESS.Constructor(null, { cli: true })
   cliInstance.log('hello'.red)
   assert.equal(loggedStr, 'hello'.red, 'console.log was called with colored string')
-
-  var options = { cli: true, stripColors: true }
-  cliInstance = new RECESS.Constructor(null, options, new Logger(options))
+  cliInstance = new RECESS.Constructor(null, { cli: true, stripColors: true })
   cliInstance.log('hello'.red)
   assert.equal(loggedStr, 'hello', 'console.log was called with color stripped string')
 
@@ -58,7 +51,7 @@ var assert = require('assert')
 !function () {
 
   var path = 'test/fixtures/property-order.css'
-    , Recess = new RECESS.Constructor(null, {}, new Logger({}))
+    , Recess = new RECESS.Constructor()
     , validate = RECESS.Constructor.prototype.validate
 
   RECESS.Constructor.prototype.validate = noop
@@ -90,7 +83,7 @@ var assert = require('assert')
 !function () {
 
   var path = 'test/fixtures/no-JS.css'
-    , Recess = new RECESS.Constructor(null, {}, new Logger({}))
+    , Recess = new RECESS.Constructor()
     , validate = RECESS.Constructor.prototype.validate
     , lines = [7, 8, 16, 16, 21, 21]
 
@@ -123,7 +116,7 @@ var assert = require('assert')
 !function () {
 
   var path = 'test/fixtures/no-IDs.css'
-    , Recess = new RECESS.Constructor(null, {}, new Logger({}))
+    , Recess = new RECESS.Constructor()
     , validate = RECESS.Constructor.prototype.validate
     , lines = [1, 7, 13]
 
@@ -152,7 +145,7 @@ var assert = require('assert')
 !function () {
 
   var path = 'test/fixtures/no-underscores.css'
-    , Recess = new RECESS.Constructor(null, {}, new Logger({}))
+    , Recess = new RECESS.Constructor()
     , validate = RECESS.Constructor.prototype.validate
     , lines = [1, 6, 6]
 
@@ -181,7 +174,7 @@ var assert = require('assert')
 !function () {
 
   var path = 'test/fixtures/universal-selectors.css'
-    , Recess = new RECESS.Constructor(null, {}, new Logger({}))
+    , Recess = new RECESS.Constructor()
     , validate = RECESS.Constructor.prototype.validate
     , counts = [1, 3, 1]
     , lines = [1, 5, 6, 7, 11]
@@ -212,7 +205,7 @@ var assert = require('assert')
 !function () {
 
   var path = 'test/fixtures/no-overqualifying.css'
-    , Recess = new RECESS.Constructor(null, {}, new Logger({}))
+    , Recess = new RECESS.Constructor()
     , validate = RECESS.Constructor.prototype.validate
     , counts = [1, 2]
     , lines = [1, 7, 8]
@@ -241,7 +234,7 @@ var assert = require('assert')
 // Cannot read property 'red' of undefined
 !function () {
 
-  var Recess = new RECESS.Constructor(null, {}, new Logger({}))
+  var Recess = new RECESS.Constructor()
     , validate = RECESS.Constructor.prototype.validate
 
   RECESS.Constructor.prototype.validate = noop
@@ -260,7 +253,7 @@ var assert = require('assert')
 !function () {
 
   var path = 'test/fixtures/inline-images.css'
-    , Recess = new RECESS.Constructor(null, {}, new Logger({}))
+    , Recess = new RECESS.Constructor()
     , validate = RECESS.Constructor.prototype.validate
     , counts = [1, 1, 1, 0]
     , lines = [2, 5, 8]
@@ -304,9 +297,3 @@ var assert = require('assert')
 
 
 console.log("✓ linting".green)
-
-/*
- * Local Variables:
- * js-indent-level: 2
- * End:
- */

--- a/test/types/lint.js
+++ b/test/types/lint.js
@@ -1,5 +1,6 @@
 var assert = require('assert')
   , RECESS = require('../../lib')
+  , Logger = require('../../lib/logger')
   , colors = require('colors')
   , fs = require('fs')
   , noop = function () {}
@@ -15,13 +16,16 @@ var assert = require('assert')
 
   console.log = function (string) { loggedStr = string }
 
-  withOutCompile = new RECESS.Constructor(null, { cli: true })
+  var options = { cli: true }
+  withOutCompile = new RECESS.Constructor(null, options, new Logger(options))
   withOutCompile.log('first')
   assert.equal(loggedStr, 'first', 'console.log was not called when compile was true')
-  withCompile = new RECESS.Constructor(false, { compile: true, cli: true})
+
+  options = { compile: true, cli: true};
+  withCompile = new RECESS.Constructor(false, options, new Logger(options))
   withCompile.log('second')
   assert.equal(loggedStr, 'first', 'console.log was not called when compile was true')
-  withCompile.log('third', true)
+  withCompile.logForce('third')
   assert.equal(loggedStr, 'third', 'console.log was called when force was was true')
 
   console.log = log
@@ -36,10 +40,13 @@ var assert = require('assert')
 
   console.log = function (string) { loggedStr = string }
 
-  cliInstance = new RECESS.Constructor(null, { cli: true })
+  var options = { cli: true }
+  cliInstance = new RECESS.Constructor(null, options, new Logger(options))
   cliInstance.log('hello'.red)
   assert.equal(loggedStr, 'hello'.red, 'console.log was called with colored string')
-  cliInstance = new RECESS.Constructor(null, { cli: true, stripColors: true })
+
+  var options = { cli: true, stripColors: true }
+  cliInstance = new RECESS.Constructor(null, options, new Logger(options))
   cliInstance.log('hello'.red)
   assert.equal(loggedStr, 'hello', 'console.log was called with color stripped string')
 
@@ -51,7 +58,7 @@ var assert = require('assert')
 !function () {
 
   var path = 'test/fixtures/property-order.css'
-    , Recess = new RECESS.Constructor()
+    , Recess = new RECESS.Constructor(null, {}, new Logger({}))
     , validate = RECESS.Constructor.prototype.validate
 
   RECESS.Constructor.prototype.validate = noop
@@ -83,7 +90,7 @@ var assert = require('assert')
 !function () {
 
   var path = 'test/fixtures/no-JS.css'
-    , Recess = new RECESS.Constructor()
+    , Recess = new RECESS.Constructor(null, {}, new Logger({}))
     , validate = RECESS.Constructor.prototype.validate
     , lines = [7, 8, 16, 16, 21, 21]
 
@@ -116,7 +123,7 @@ var assert = require('assert')
 !function () {
 
   var path = 'test/fixtures/no-IDs.css'
-    , Recess = new RECESS.Constructor()
+    , Recess = new RECESS.Constructor(null, {}, new Logger({}))
     , validate = RECESS.Constructor.prototype.validate
     , lines = [1, 7, 13]
 
@@ -145,7 +152,7 @@ var assert = require('assert')
 !function () {
 
   var path = 'test/fixtures/no-underscores.css'
-    , Recess = new RECESS.Constructor()
+    , Recess = new RECESS.Constructor(null, {}, new Logger({}))
     , validate = RECESS.Constructor.prototype.validate
     , lines = [1, 6, 6]
 
@@ -174,7 +181,7 @@ var assert = require('assert')
 !function () {
 
   var path = 'test/fixtures/universal-selectors.css'
-    , Recess = new RECESS.Constructor()
+    , Recess = new RECESS.Constructor(null, {}, new Logger({}))
     , validate = RECESS.Constructor.prototype.validate
     , counts = [1, 3, 1]
     , lines = [1, 5, 6, 7, 11]
@@ -205,7 +212,7 @@ var assert = require('assert')
 !function () {
 
   var path = 'test/fixtures/no-overqualifying.css'
-    , Recess = new RECESS.Constructor()
+    , Recess = new RECESS.Constructor(null, {}, new Logger({}))
     , validate = RECESS.Constructor.prototype.validate
     , counts = [1, 2]
     , lines = [1, 7, 8]
@@ -234,7 +241,7 @@ var assert = require('assert')
 // Cannot read property 'red' of undefined
 !function () {
 
-  var Recess = new RECESS.Constructor()
+  var Recess = new RECESS.Constructor(null, {}, new Logger({}))
     , validate = RECESS.Constructor.prototype.validate
 
   RECESS.Constructor.prototype.validate = noop
@@ -253,7 +260,7 @@ var assert = require('assert')
 !function () {
 
   var path = 'test/fixtures/inline-images.css'
-    , Recess = new RECESS.Constructor()
+    , Recess = new RECESS.Constructor(null, {}, new Logger({}))
     , validate = RECESS.Constructor.prototype.validate
     , counts = [1, 1, 1, 0]
     , lines = [2, 5, 8]
@@ -297,3 +304,9 @@ var assert = require('assert')
 
 
 console.log("✓ linting".green)
+
+/*
+ * Local Variables:
+ * js-indent-level: 2
+ * End:
+ */


### PR DESCRIPTION
Useful for CI integration (jenkins / bamboo).

Changes should be backwards-compatible: recess() function has new 4th optional parameter added, but the default behavior is the same as before.

I've added several cucumber features both for regression testing and for testing new functionality.
