### PR TITLE
Support less' rootpath and relativeUrls options

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ OPTIONS
   - --format compact - show errors one-error-per-line, useful for IDE integration
 - --noSummary - don't output the summary block for each file
 - --includePath - accepts an additional directory path to look for `@import`:ed LESS files in.
+- --urlRootPath - adds a base path to every url.
+- --relativeUrls - rewrites urls to be relative to the entry file.
 - --stripColors - removes color from output (useful when logging)
 - --watch - watch filesystem for changes, useful when compiling Less projects
 - --noIDs - doesn't complain about using IDs in your stylesheets

--- a/bin/recess
+++ b/bin/recess
@@ -20,6 +20,8 @@ options = {
 , config: path
 , format: String
 , includePath: [path, Array]
+, urlRootPath: String
+, relativeUrls: Boolean
 , noIDs: Boolean
 , noJSPrefix: Boolean
 , noOverqualifying: Boolean

--- a/lib/core.js
+++ b/lib/core.js
@@ -68,6 +68,8 @@ RECESS.prototype = {
     var that = this
       , options = {
           paths: [path.dirname(this.path)].concat(this.options.includePath)
+        , rootpath: this.options.urlRootPath
+        , relativeUrls: this.options.relativeUrls
         , optimization: 0
         , filename: this.path && this.path.replace(/.*(?=\/)\//, '')
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -76,6 +76,8 @@ module.exports.DEFAULTS = RECESS.DEFAULTS = {
 , config: false
 , format: 'text'
 , includePath: []
+, urlRootPath: ''
+, relativeUrls: false
 , noIDs: true
 , noJSPrefix: true
 , noOverqualifying: true


### PR DESCRIPTION
- The rootpath and relativeUrls options were added to less in version
  1.3.2
- rootpath exposed as urlRootPath to make more sense along with the
  other available recess options than just "rootpath" would. Also,
  camelCase.

This allows properly compiling Less files that import from a subfolder with Less files referencing image or font files in that same subfolder, without having to flatten the file hierarchy, by updating urls to be relative to the main Less file's location. The same functionality was used to fix up browser-side loading when updating from Less 1.3.1 to 1.3.3 (The breaking change happened in 1.3.2).
