### PR TITLE
Update stripColors for new colors.js API

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -33,7 +33,7 @@ RECESS.prototype = {
 
 , log: function (str, force) {
 
-    if (this.options.stripColors) str = str.stripColors
+    if (this.options.stripColors) str = str.strip
 
     // if compiling only write with force flag
     if (!this.options.compile || force) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,7 +39,7 @@ module.exports = function (paths, options, callback) {
   // if not compiling, let user know which files will be linted
   if (!options.compile && options.cli && !options.noSummary) {
     message = "\nAnalyzing the following files: " + ((paths + '').replace(/,/g, ', ') + '\n').grey
-    options.stripColors && (message = message.stripColors)
+    options.stripColors && (message = message.strip)
     console.log(message)
   }
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 , "main": "./lib"
 , "homepage": "http://twitter.github.com/recess"
 , "engines": { "node": ">= 0.4.0" }
-, "dependencies": { "colors": ">= 0.3.0", "nopt": ">= 1.0.10", "underscore": ">= 1.2.1", "watch": ">= 0.5.1", "less": "~1.3.0" }
+, "dependencies": { "colors": ">= 1.0.0", "nopt": ">= 1.0.10", "underscore": ">= 1.2.1", "watch": ">= 0.5.1", "less": "~1.3.0" }
 , "directories": { "bin": "./bin" }
 , "scripts": { "test": "node test" }
 , "bin": { "recess": "./bin/recess" }


### PR DESCRIPTION
- 'stripColors' was renamed to just 'strip' in colors.js 1.0.0.
