### PR TITLE
Update resolve-dep package to avoid globule error

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "lodash": "^2.4.1",
     "mime": ">=1.2.9",
     "nopt": ">= 1.0.10",
-    "resolve-dep": "^0.3.4",
+    "resolve-dep": "^0.5.3",
     "watch": ">= 0.5.1"
   },
   "directories": {


### PR DESCRIPTION
As noted in assemble/assemble#539, the older version of the resolve-dep package
causes an error message about a missing `globule` module. Updating to the latest
version fixes this.