### PR TITLE
Fix empty lines logging

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -121,12 +121,12 @@ RECESS.prototype.parse = function () {
 
           // parse error
           self.log(chalk.red('Parser error') + (err.filename ? ' in ' + chalk.yellow(err.filename) : ''));
-          self.log();
+          self.log(' ');
         } else {
 
           // other exception
           self.log(chalk.red(err.name) + ': ' + err.message + (err.filename ? ' of ' + chalk.yellow(err.filename) : ''));
-          self.log();
+          self.log(' ');
         }
 
         // if extract - then log it

--- a/lib/info.js
+++ b/lib/info.js
@@ -17,9 +17,9 @@ var RECESS = require('./core');
 
 // expose docs
 exports.docs = function () {
-  console.log();
+  console.log(' ');
   console.log(chalk.gray('GENERAL USE: ' + '$') + chalk.cyan(' recess') + chalk.yellow(' [path] ') + chalk.gray('[options]'));
-  console.log();
+  console.log(' ');
   console.log('OPTIONS (with defaults):');
 
   for (var option in RECESS.DEFAULTS) {
@@ -28,12 +28,12 @@ exports.docs = function () {
     }
   }
 
-  console.log();
+  console.log(' ');
   console.log('EXAMPLE:');
-  console.log();
-  console.log();
+  console.log(' ');
+  console.log(' ');
   console.log(chalk.gray('  $') + chalk.cyan(' recess') + chalk.yellow(' ./bootstrap.css ') + chalk.gray('--noIDs false'));
-  console.log();
+  console.log(' ');
   console.log(chalk.yellow('GENERAL HELP: ' + 'http://git.io/recess'));
-  console.log();
+  console.log(' ');
 };


### PR DESCRIPTION
With no parameters, the log method outputs `undefined` on the command line.
